### PR TITLE
Implement ability to search cases by file ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # General
 *.log
 .DS_Store
+__target__
 
 # IDE
 .idea/

--- a/app/case/forms.py
+++ b/app/case/forms.py
@@ -378,6 +378,7 @@ class IssueSearchForm(forms.ModelForm):
                     | Q(client__first_name__icontains=search_part)
                     | Q(client__last_name__icontains=search_part)
                     | Q(client__email__icontains=search_part)
+                    | Q(fileref__icontains=search_part)
                 )
                 if search_query:
                     search_query |= part_query

--- a/app/case/templates/case/case/list.html
+++ b/app/case/templates/case/case/list.html
@@ -71,7 +71,7 @@
         hx-swap="outerHTML"
         hx-trigger="change, keyup delay:0.3s"
     >
-        {% include 'case/forms/_text_field.html' with field=form.search placeholder="Search for paralegals or clients by name or email" %}
+        {% include 'case/forms/_text_field.html' with field=form.search placeholder="Find cases with the name or email of paralegals and clients, or by using the file ref" %}
         <div class="equal width fields">
             {% include 'case/forms/_dropdown_field.html' with field=form.topic %}
             {% include 'case/forms/_dropdown_field.html' with field=form.stage %}


### PR DESCRIPTION
We can now search for cases using file ref, this is a fuzzy case-insensitive match, just like the searching by paralegal/coordinator name or email.

Have user tested the change and the requested functionality, plus previous functionality, is in place.