### PR TITLE
Update infra/deploy.sh to remove unused Docker objects after deployment

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -50,5 +50,8 @@ ssh -o StrictHostKeyChecking=no -i deploy.key root@$HOST /bin/bash << EOF
     cd $DEPLOY_DIR
     echo -e "\n>>> Deploying $PROJECT to Docker Swarm cluster from $DEPLOY_DIR"
     docker stack deploy --compose-file docker-compose.${COMPOSE_SUFFIX}.yml $PROJECT
+    echo -e "\n>>> Removing unused Docker objects (containers, images, volumes, networks, build cache)"
+    docker system prune --volumes -f
 EOF
+
 echo -e "\n>>> Deployment finished for $PROJECT"


### PR DESCRIPTION
Very simple change: I went with `docker system prune --volumes -f` instead of `docker image prune -af`. This is because after deployment there are other unused Docker objects like containers in addition to images.